### PR TITLE
reformatted JavaScript modules with Prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,3 +10,6 @@ extends:
 
 rules:
     compat/compat: error
+    indent: off
+    keyword-spacing: off
+    dot-location: off

--- a/components/_preview.jsx
+++ b/components/_preview.jsx
@@ -14,24 +14,29 @@ let scripts = [
 ];
 
 export default function PreviewLayout({ context }, ...children) {
-	return <html lang="en">
-		<head>
-			<meta charset="utf-8" />
-			<title>{title}</title>
-			<meta name="viewport" content="width=device-width, initial-scale=1" />
-			{renderStyleSheets(stylesheets)}
-		</head>
+	return (
+		<html lang="en">
+			<head>
+				<meta charset="utf-8" />
+				<title>{title}</title>
+				<meta
+					name="viewport"
+					content="width=device-width, initial-scale=1"
+				/>
+				{renderStyleSheets(stylesheets)}
+			</head>
 
-		<body>
-			{children}
+			<body>
+				{children}
 
-			{renderScripts(scripts)}
-		</body>
-	</html>;
+				{renderScripts(scripts)}
+			</body>
+		</html>
+	);
 }
 
 function renderStyleSheets(items) {
-	if(!items || !items.length) {
+	if (!items || !items.length) {
 		return;
 	}
 
@@ -41,7 +46,7 @@ function renderStyleSheets(items) {
 }
 
 function renderScripts(items) {
-	if(!items || !items.length) {
+	if (!items || !items.length) {
 		return;
 	}
 

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -1,31 +1,42 @@
 import { createElement } from "complate-stream";
 
-export function Alert({ contextual, headline, withCloseButton, withFadeOut }, ...children) {
+export function Alert(
+	{ contextual, headline, withCloseButton, withFadeOut },
+	...children
+) {
 	let classNames = ["alert"];
 	let headlineRow;
 	let closeButton;
 
-	if(contextual) {
+	if (contextual) {
 		classNames.push(`alert-${contextual}`);
 	}
 
-	if(headline) {
+	if (headline) {
 		headlineRow = <h4 class="alert-heading">{headline}</h4>;
 	}
 
-	if(withCloseButton) {
+	if (withCloseButton) {
 		classNames.push("alert-dismissible");
-		if(withFadeOut) {
+		if (withFadeOut) {
 			classNames.push("fade show");
 		}
-		closeButton = <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-			<span aria-hidden="true">&times;</span>
-		</button>;
+		closeButton = (
+			<button
+				type="button"
+				class="close"
+				data-dismiss="alert"
+				aria-label="Close">
+				<span aria-hidden="true">&times;</span>
+			</button>
+		);
 	}
 
-	return <div class={classNames.join(" ")} role="alert">
-		{headlineRow}
-		{children}
-		{closeButton}
-	</div>;
+	return (
+		<div class={classNames.join(" ")} role="alert">
+			{headlineRow}
+			{children}
+			{closeButton}
+		</div>
+	);
 }

--- a/components/badge/index.jsx
+++ b/components/badge/index.jsx
@@ -1,17 +1,20 @@
 import { createElement } from "complate-stream";
 
-export default function Badge({ class: additionalClass, contextual = "secondary", href, pill }, ...children) {
+export default function Badge(
+	{ class: additionalClass, contextual = "secondary", href, pill },
+	...children
+) {
 	let tag = "span";
 	let attrs = {};
-	if(href) {
+	if (href) {
 		tag = "a";
 		attrs["href"] = href;
 	}
 	let classNames = ["badge", `badge-${contextual}`];
-	if(pill) {
+	if (pill) {
 		classNames.push("badge-pill");
 	}
-	if(!additionalClass) {
+	if (!additionalClass) {
 		classNames.push(additionalClass);
 	}
 	attrs["class"] = classNames.join(" ");

--- a/components/button-group/index.jsx
+++ b/components/button-group/index.jsx
@@ -1,13 +1,18 @@
 import { createElement } from "complate-stream";
 
-export default function ButtonGroup({ class: additionalClass, ariaLabel }, ...children) {
+export default function ButtonGroup(
+	{ class: additionalClass, ariaLabel },
+	...children
+) {
 	let classNames = ["btn-group"];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		classNames.push(additionalClass);
 	}
 
-	return <div class={classNames.join(" ")} role="group" aria-label={ariaLabel}>
-		{children}
-	</div>;
+	return (
+		<div class={classNames.join(" ")} role="group" aria-label={ariaLabel}>
+			{children}
+		</div>
+	);
 }

--- a/components/button-toolbar/index.jsx
+++ b/components/button-toolbar/index.jsx
@@ -1,13 +1,18 @@
 import { createElement } from "complate-stream";
 
-export default function ButtonToolbar({ class: additionalClass, ariaLabel }, ...children) {
+export default function ButtonToolbar(
+	{ class: additionalClass, ariaLabel },
+	...children
+) {
 	let classNames = ["btn-toolbar"];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		classNames.push(additionalClass);
 	}
 
-	return <div class={classNames.join(" ")} role="toolbar" aria-label={ariaLabel}>
-		{children}
-	</div>;
+	return (
+		<div class={classNames.join(" ")} role="toolbar" aria-label={ariaLabel}>
+			{children}
+		</div>
+	);
 }

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -1,39 +1,58 @@
 import { createElement } from "complate-stream";
 
-export default function Button({ class: additionalClass, active, disabled, block, outline, contextual, title, type: typeName, size }, ...children) {
+export default function Button(
+	{
+		class: additionalClass,
+		active,
+		disabled,
+		block,
+		outline,
+		contextual,
+		title,
+		type: typeName,
+		size
+	},
+	...children
+) {
 	let classNames = ["btn"];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		classNames.push(additionalClass);
 	}
 
-	if(active) {
+	if (active) {
 		classNames.push("active");
 	}
 
-	if(disabled) {
+	if (disabled) {
 		classNames.push("disabled");
 	}
 
-	if(contextual && outline) {
+	if (contextual && outline) {
 		classNames.push(`btn-outline-${contextual}`);
-	} else if(contextual) {
+	} else if (contextual) {
 		classNames.push(`btn-${contextual}`);
 	}
 
-	if(size) {
+	if (size) {
 		classNames.push(`btn-${size}`);
 	}
 
-	if(block) {
+	if (block) {
 		classNames.push("btn-block");
 	}
 
-	if(!typeName) {
+	if (!typeName) {
 		typeName = "button";
 	}
 
-	return <button disabled={disabled} type={typeName} class={classNames.join(" ")} title={title}>
-		{children}
-	</button>;
+	return (
+		<button
+			disabled={disabled}
+			type={typeName}
+			class={classNames.join(" ")}
+			title={title}>
+			{children}
+		</button>
+	);
 }

--- a/components/dropdown/index.jsx
+++ b/components/dropdown/index.jsx
@@ -1,30 +1,50 @@
 import { createElement } from "complate-stream";
 
-export default function Dropdown({ id, class: additionalClass, label, contextual = "secondary", active, disabled, type: typeName = "button", size }, ...children) {
+export default function Dropdown(
+	{
+		id,
+		class: additionalClass,
+		label,
+		contextual = "secondary",
+		active,
+		disabled,
+		type: typeName = "button",
+		size
+	},
+	...children
+) {
 	let classNames = ["dropdown-toggle", "btn", `btn-${contextual}`];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		classNames.push(additionalClass);
 	}
 
-	if(active) {
+	if (active) {
 		classNames.push("active");
 	}
 
-	if(disabled) {
+	if (disabled) {
 		classNames.push("disabled");
 	}
 
-	if(size) {
+	if (size) {
 		classNames.push(`btn-${size}`);
 	}
 
-	return <div class="dropdown">
-		<button class={classNames.join(" ")} data-toggle="dropdown" type={typeName} id={id} aria-haspopup="true" aria-expanded="false">
-			{label}
-		</button>
-		<div class="dropdown-menu" aria-labelledby={id}>
-			{children}
+	return (
+		<div class="dropdown">
+			<button
+				class={classNames.join(" ")}
+				data-toggle="dropdown"
+				type={typeName}
+				id={id}
+				aria-haspopup="true"
+				aria-expanded="false">
+				{label}
+			</button>
+			<div class="dropdown-menu" aria-labelledby={id}>
+				{children}
+			</div>
 		</div>
-	</div>;
+	);
 }

--- a/components/link/index.jsx
+++ b/components/link/index.jsx
@@ -3,12 +3,16 @@ import { createElement } from "complate-stream";
 export default function Link(params, ...children) {
 	let { active, disabled, href, title } = params;
 	let classes = ["nav-link"];
-	if(active) {
+	if (active) {
 		classes.push("active");
 	}
-	if(disabled) {
+	if (disabled) {
 		classes.push("disabled");
 	}
 
-	return <a class={classes.join(" ")} href={href} title={title}>{children}</a>;
+	return (
+		<a class={classes.join(" ")} href={href} title={title}>
+			{children}
+		</a>
+	);
 }

--- a/components/list-group/index.jsx
+++ b/components/list-group/index.jsx
@@ -3,41 +3,46 @@ import { createElement } from "complate-stream";
 export function ListGroup({ class: additionalClass }, ...children) {
 	let klass = ["list-group"];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		klass.push(additionalClass);
 	}
 
-	return <ul class={ klass.join(" ") }>
-		{children}
-	</ul>;
+	return <ul class={klass.join(" ")}>{children}</ul>;
 }
 
-export function ListGroupItem({ class: additionalClass, active, disabled, contextual, href }, ...children) {
+export function ListGroupItem(
+	{ class: additionalClass, active, disabled, contextual, href },
+	...children
+) {
 	let klass = ["list-group-item"];
 
-	if(additionalClass) {
+	if (additionalClass) {
 		klass.push(additionalClass);
 	}
 
-	if(active) {
+	if (active) {
 		klass.push("active");
 	}
 
-	if(disabled) {
+	if (disabled) {
 		klass.push("disabled");
 	}
 
-	if(contextual) {
+	if (contextual) {
 		klass.push(`list-group-item-${contextual}`);
 	}
 
 	let listGroupItem;
 
-	if(href) {
+	if (href) {
 		klass.push("list-group-item-action");
-		listGroupItem = <a href={ href } class={ klass.join(" ") }>{children}</a>;
+		listGroupItem = (
+			<a href={href} class={klass.join(" ")}>
+				{children}
+			</a>
+		);
 	} else {
-		listGroupItem = <li class={ klass.join(" ") }>{children}</li>;
+		listGroupItem = <li class={klass.join(" ")}>{children}</li>;
 	}
 
 	return listGroupItem;

--- a/components/navigation/index.jsx
+++ b/components/navigation/index.jsx
@@ -3,23 +3,24 @@ import { createElement } from "complate-stream";
 export default function Navigation(params, ...children) {
 	let { alignment, withFlexColumns, size, variant } = params;
 	let classes = ["nav"];
-	if(variant) {
+	if (variant) {
 		classes.push("nav-" + variant);
 	}
-	if(size) {
+	if (size) {
 		classes.push("nav-" + size);
 	}
-	if(alignment) {
+	if (alignment) {
 		classes.push(alignment);
 	}
-	if(withFlexColumns) {
+	if (withFlexColumns) {
 		classes.push("flex-column");
 	}
 
-	return <ul class={classes.join(" ")}>
-		{children.map(child => {
-			return <li class="nav-item">{child}</li>;
-		}
-		)}
-	</ul>;
+	return (
+		<ul class={classes.join(" ")}>
+			{children.map(child => {
+				return <li class="nav-item">{child}</li>;
+			})}
+		</ul>
+	);
 }

--- a/components/pagination/index.jsx
+++ b/components/pagination/index.jsx
@@ -1,36 +1,39 @@
 import { createElement } from "complate-stream";
 
-export function Pagination({ "aria-label": label, class: additionalClass, size }, ...children) {
+export function Pagination(
+	{ "aria-label": label, class: additionalClass, size },
+	...children
+) {
 	let klass = ["pagination"];
-	if(additionalClass) {
+	if (additionalClass) {
 		klass.push(additionalClass);
 	}
-	if(size) {
+	if (size) {
 		klass.push(`pagination-${size}`);
 	}
-	return <nav aria-label={label}>
-		<ul class={klass.join(" ")}>
-			{children}
-		</ul>
-	</nav>;
+	return (
+		<nav aria-label={label}>
+			<ul class={klass.join(" ")}>{children}</ul>
+		</nav>
+	);
 }
 
 export function PageItem({ active, disabled, href }, ...children) {
 	let tag = "span";
 	let attrs = { class: "page-link" };
 	let klass = ["page-item"];
-	if(active) {
+	if (active) {
 		klass.push("active");
 	}
-	if(disabled || !href) {
+	if (disabled || !href) {
 		klass.push("disabled");
 		attrs["tabindex"] = -1;
 	}
-	if(href) {
+	if (href) {
 		tag = "a";
 		attrs["href"] = href;
 	}
-	return <li class={klass.join(" ")}>
-		{createElement(tag, attrs, children)}
-	</li>;
+	return (
+		<li class={klass.join(" ")}>{createElement(tag, attrs, children)}</li>
+	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8196,6 +8196,12 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 			"dev": true
 		},
+		"prettier": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+			"integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+			"dev": true
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
 	"scripts": {
 		"start": "npm-run-all --parallel server-watch compile-watch",
-		"test": "eslint --cache --ext .js --ext .jsx --ignore-path .gitignore *.js lib components && echo ✓",
+		"test": "npm-run-all --parallel format lint",
+		"lint": "eslint --cache --ext .js --ext .jsx --ignore-path .gitignore *.js lib components && echo ✓",
+		"format": "prettier --jsx-bracket-same-line true --list-different --write '{lib/scripts,components}/**/*.js{,x}'",
 		"dist": "npm run compile && npm run site",
 		"site": "fractal build",
 		"server-watch": "nodemon -I -w components -e jsx -x 'npm run server'",
@@ -18,6 +20,7 @@
 		"faucet-pipeline-js": "^0.15.5",
 		"faucet-pipeline-sass": "^0.9.0",
 		"nodemon": "^1.12.1",
-		"npm-run-all": "^4.1.2"
+		"npm-run-all": "^4.1.2",
+		"prettier": "^1.10.2"
 	}
 }


### PR DESCRIPTION
→ [Prettier](https://prettier.io)

> this ensures consistency without inducing unnecessary overhead/headaches (modulo OCD)

90266e4fe00b394a2a9d8d90ab848ae8e35585e2

with a crowd of contributors this diverse (screw whitespace privilege ✊ ), opinionated auto-formatting seems [better than the alternative](https://www.youtube.com/watch?v=lR9WjYi-G2Q) 🤕

caveats:

* contributors are expected to run `npm run format`, before every single commit
* formatting is not currently being verified by CI
* a few of Prettier's opinions reduce readability¹ - since it's (intentionally) not highly configurable, we'll probably have to live with that; see above

¹ notably the lack of double indentation for line continuations as well as spurious parentheses (and additional indentation) around XML blocks - feel free to join in with your own ineffectual whining